### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tinted-theming/builder-ruby

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Omar
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # base16-builder-ruby
-This is a base16 builder written in Ruby as defined by the [base16 builder guidelines](https://github.com/chriskempson/base16/blob/39d01a0248c7b28863ebafca66d7e1f5ca867b13/builder.md) version 0.9.0
+This is a base16 builder written in Ruby as defined by the [base16 builder guidelines](https://github.com/tinted-theming/home/blob/cc34890294402b9052b528e107f5b6b5ae15fdff/builder.md) version 0.9.0
 
 ## Requirements
 * Ruby 2.3.0+ (You can use [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/) to acquire a specific Ruby version)


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.