### PR TITLE
Enable building with modern Ruby versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,14 @@ GEM
   specs:
     chroma (0.1.0)
     git (1.3.0)
-    mustache (1.0.3)
+    mustache (1.1.1)
     parallel (1.11.1)
     safe_yaml (1.0.5)
     slugify (1.0.7)
     thor (0.19.4)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   chroma
@@ -22,4 +22,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.14.6
+   2.3.26

--- a/builder
+++ b/builder
@@ -11,8 +11,8 @@ class Builder < Thor
 
   no_commands do
     def required_dirs_exist?
-      return Dir.exists?("sources") && Dir.exists?("schemes") &&
-        Dir.exists?("templates")
+      return Dir.exist?("sources") && Dir.exist?("schemes") &&
+        Dir.exist?("templates")
     end
   end
   desc "update", "Re-acquires all sources, schemes, and templates"

--- a/src/base16_repository.rb
+++ b/src/base16_repository.rb
@@ -36,7 +36,7 @@ class Base16Repository
   end
 
   def update
-    if exists?
+    if exist?
       puts "Pulling #{@repo_path}..."
       repo = Git.open(@repo_path)
       repo.pull
@@ -50,8 +50,8 @@ class Base16Repository
     Git.clone(@url, @name, path: @path, depth: 1)
   end
 
-  def exists?
-    Dir.exists?(@repo_path)
+  def exist?
+    Dir.exist?(@repo_path)
   end
 
   def is_scheme_list_repo?
@@ -63,12 +63,12 @@ class Base16Repository
   end
 
   def scheme_repo_urls
-    return nil unless exists? && is_scheme_list_repo?
+    return nil unless exist? && is_scheme_list_repo?
     SafeYAML.load(File.read("#{@repo_path}/list.yaml"))
   end
 
   def template_repo_urls
-    return nil unless exists? && is_template_list_repo?
+    return nil unless exist? && is_template_list_repo?
     SafeYAML.load(File.read("#{@repo_path}/list.yaml"))
   end
 end

--- a/src/template.rb
+++ b/src/template.rb
@@ -31,7 +31,7 @@ class Template
 
       rendered_template = Mustache.render(File.read(template_file), template_data)
 
-      FileUtils.mkdir_p(rendered_dir) unless Dir.exists?(rendered_dir)
+      FileUtils.mkdir_p(rendered_dir) unless Dir.exist?(rendered_dir)
 
       puts "building #{rendered_dir}/#{rendered_filename}"
       File.write("#{rendered_dir}/#{rendered_filename}", rendered_template)


### PR DESCRIPTION
Update Bundler version for Ruby 3.2

Previously, Bundler would use version 1.14.6 specified in the
Gemfile.lock. However, this version of Bundler uses the #untaint method
which was removed in Ruby 3.2.

To fix this, the locked version of Bundler has been updated. The version
chosen is the last 2.3.x release as 2.4 drops support for Rubyies 2.3 -
2.5. If dropping support for EoL Rubies is not an issue then the Bundler
version could be upgraded further.

---

Replace #exists? with #exist?

The #exists? method has been deprecated since Ruby 2.1.0 and was finally
removed in Ruby 3.0